### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules/
+/node_modules/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Linus Unnebäck
+Copyright (c) 2015-2021 Linus Unnebäck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+/** Adds the field named `key` with the value `value` to the object `store`. */
+export default function appendField (store: object, key: string, value: any): void

--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
-var parsePath = require('./lib/parse-path')
-var setValue = require('./lib/set-value')
+import parsePath from './lib/parse-path.js'
+import setValue from './lib/set-value.js'
 
-function appendField (store, key, value) {
-  var steps = parsePath(key)
+export default function appendField (store, key, value) {
+  const steps = parsePath(key)
 
-  steps.reduce(function (context, step) {
+  steps.reduce((context, step) => {
     return setValue(context, step, context[step.key], value)
   }, store)
 }
-
-module.exports = appendField

--- a/lib/parse-path.js
+++ b/lib/parse-path.js
@@ -1,22 +1,22 @@
-var reFirstKey = /^[^\[]*/
-var reDigitPath = /^\[(\d+)\]/
-var reNormalPath = /^\[([^\]]+)\]/
+const reFirstKey = /^[^[]*/
+const reDigitPath = /^\[(\d+)\]/
+const reNormalPath = /^\[([^\]]+)\]/
 
-function parsePath (key) {
+export default function parsePath (key) {
   function failure () {
-    return [{ type: 'object', key: key, last: true }]
+    return [{ type: 'object', key, last: true }]
   }
 
-  var firstKey = reFirstKey.exec(key)[0]
+  const firstKey = reFirstKey.exec(key)[0]
   if (!firstKey) return failure()
 
-  var len = key.length
-  var pos = firstKey.length
-  var tail = { type: 'object', key: firstKey }
-  var steps = [tail]
+  const len = key.length
+  let pos = firstKey.length
+  let tail = { type: 'object', key: firstKey }
+  const steps = [tail]
 
   while (pos < len) {
-    var m
+    let m
 
     if (key[pos] === '[' && key[pos + 1] === ']') {
       pos += 2
@@ -49,5 +49,3 @@ function parsePath (key) {
   tail.last = true
   return steps
 }
-
-module.exports = parsePath

--- a/lib/set-value.js
+++ b/lib/set-value.js
@@ -27,38 +27,43 @@ function setLastValue (context, step, currentValue, entryValue) {
   return context
 }
 
-function setValue (context, step, currentValue, entryValue) {
+export default function setValue (context, step, currentValue, entryValue) {
   if (step.last) return setLastValue(context, step, currentValue, entryValue)
 
-  var obj
   switch (valueType(currentValue)) {
-    case 'undefined':
+    case 'undefined': {
       if (step.nextType === 'array') {
         context[step.key] = []
       } else {
         context[step.key] = Object.create(null)
       }
+
       return context[step.key]
-    case 'object':
+    }
+
+    case 'object': {
       return context[step.key]
-    case 'array':
+    }
+
+    case 'array': {
       if (step.nextType === 'array') {
         return currentValue
       }
 
-      obj = Object.create(null)
+      const obj = Object.create(null)
       context[step.key] = obj
       currentValue.forEach(function (item, i) {
         if (item !== undefined) obj['' + i] = item
       })
 
       return obj
-    case 'scalar':
-      obj = Object.create(null)
+    }
+
+    case 'scalar': {
+      const obj = Object.create(null)
       obj[''] = currentValue
       context[step.key] = obj
       return obj
+    }
   }
 }
-
-module.exports = setValue

--- a/package.json
+++ b/package.json
@@ -2,18 +2,19 @@
   "name": "append-field",
   "version": "1.0.0",
   "license": "MIT",
-  "author": "Linus Unnebäck <linus@folkdatorn.se>",
-  "main": "index.js",
-  "devDependencies": {
-    "mocha": "^2.2.4",
-    "standard": "^6.0.5",
-    "testdata-w3c-json-form": "^0.2.0"
-  },
+  "repository": "LinusU/node-append-field",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
-    "test": "standard && mocha"
+    "test": "standard && mocha && ts-readme-generator --check"
   },
-  "repository": {
-    "type": "git",
-    "url": "http://github.com/LinusU/node-append-field.git"
+  "devDependencies": {
+    "mocha": "^8.4.0",
+    "standard": "^16.0.3",
+    "testdata-w3c-json-form": "^0.2.0",
+    "ts-readme-generator": "^0.5.2"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,9 @@ npm install --save append-field
 ## Usage
 
 ```javascript
-var appendField = require('append-field')
-var obj = Object.create(null)
+import appendField from 'append-field'
+
+const obj = Object.create(null)
 
 appendField(obj, 'pets[0][species]', 'Dahut')
 appendField(obj, 'pets[0][name]', 'Hypatia')
@@ -36,6 +37,10 @@ console.log(obj)
 ## API
 
 ### `appendField(store, key, value)`
+
+- `store` (`object`, required)
+- `key` (`string`, required)
+- `value` (`any`, required)
 
 Adds the field named `key` with the value `value` to the object `store`.
 

--- a/test/forms.js
+++ b/test/forms.js
@@ -1,15 +1,15 @@
 /* eslint-env mocha */
 
-var assert = require('assert')
-var appendField = require('../')
-var testData = require('testdata-w3c-json-form')
+import assert from 'node:assert'
+import testData from 'testdata-w3c-json-form'
+import appendField from '../index.js'
 
-describe('Append Field', function () {
-  for (var test of testData) {
-    it('handles ' + test.name, function () {
-      var store = Object.create(null)
+describe('Append Field', () => {
+  for (const test of testData) {
+    it(`handles ${test.name}`, () => {
+      const store = Object.create(null)
 
-      for (var field of test.fields) {
+      for (const field of test.fields) {
         appendField(store, field.key, field.value)
       }
 


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`