### PR TITLE
feat: switch from esm to cjs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,0 @@
-/** Adds the field named `key` with the value `value` to the object `store`. */
-export default function appendField (store: object, key: string, value: any): void

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
-import parsePath from './lib/parse-path.js'
-import setValue from './lib/set-value.js'
+const parsePath = require('./lib/parse-path.js')
+const setValue = require('./lib/set-value.js')
 
-export default function appendField (store, key, value) {
+function appendField (store, key, value) {
   const steps = parsePath(key)
 
   steps.reduce((context, step) => {
     return setValue(context, step, context[step.key], value)
   }, store)
 }
+
+module.exports = appendField

--- a/lib/parse-path.js
+++ b/lib/parse-path.js
@@ -2,7 +2,7 @@ const reFirstKey = /^[^[]*/
 const reDigitPath = /^\[(\d+)\]/
 const reNormalPath = /^\[([^\]]+)\]/
 
-export default function parsePath (key) {
+function parsePath (key) {
   function failure () {
     return [{ type: 'object', key, last: true }]
   }
@@ -49,3 +49,5 @@ export default function parsePath (key) {
   tail.last = true
   return steps
 }
+
+module.exports = parsePath

--- a/lib/set-value.js
+++ b/lib/set-value.js
@@ -27,7 +27,7 @@ function setLastValue (context, step, currentValue, entryValue) {
   return context
 }
 
-export default function setValue (context, step, currentValue, entryValue) {
+function setValue (context, step, currentValue, entryValue) {
   if (step.last) return setLastValue(context, step, currentValue, entryValue)
 
   switch (valueType(currentValue)) {
@@ -67,3 +67,5 @@ export default function setValue (context, step, currentValue, entryValue) {
     }
   }
 }
+
+module.exports = setValue

--- a/package.json
+++ b/package.json
@@ -3,16 +3,18 @@
   "version": "2.0.0",
   "license": "MIT",
   "repository": "LinusU/node-append-field",
-  "type": "module",
-  "exports": "./index.js",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "scripts": {
-    "test": "standard && mocha && ts-readme-generator --check"
+    "test": "standard && mocha"
   },
   "devDependencies": {
     "mocha": "^8.4.0",
     "standard": "^16.0.3",
-    "testdata-w3c-json-form": "^0.2.0",
-    "ts-readme-generator": "^0.5.2"
+    "testdata-w3c-json-form": "^0.2.0"
   },
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"

--- a/test/forms.js
+++ b/test/forms.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 
-import assert from 'node:assert'
-import testData from 'testdata-w3c-json-form'
-import appendField from '../index.js'
+const assert = require('node:assert')
+const testData = require('testdata-w3c-json-form')
+const appendField = require('../index.js')
 
 describe('Append Field', () => {
   for (const test of testData) {


### PR DESCRIPTION
This library is incredibly small and supporting both CJS and ESM across the Express and Koa communities is very important.